### PR TITLE
Fix: Correct redirection to error.html and final.html in custom portals

### DIFF
--- a/customportals.sh
+++ b/customportals.sh
@@ -338,13 +338,16 @@ function customportals_override_set_captive_portal_page() {
 			echo '</html>'
 
 			if [ "\${et_successful}" -eq 1 ]; then
-				exit 0
-			else
-				echo '<script type="text/javascript">'
-				echo -e '\tsetTimeout("redirect()", 3500);'
-				echo '</script>'
-				exit 1
-			fi
+                echo '<script type="text/javascript">'
+                echo -e '\tsetTimeout("redirectfinal()", 0);'
+                echo '</script>'
+                exit 0
+            else
+                echo '<script type="text/javascript">'
+                echo -e '\tsetTimeout("redirecterror()", 0);'
+                echo '</script>'
+                exit 1
+            fi
 		EOF
 
 		exec 4>&-


### PR DESCRIPTION
Hi @xpz3 ,
I noticed a bug in customportals.sh where custom portals fail to load their specific error.html and final.html pages. Instead, the plugin falls back to Airgeddon's standard behavior (showing the default green text message and redirecting back to index.html).
The Problem:
Inside the function customportals_override_set_captive_portal_page(), the JavaScript functions redirecterror() and redirectfinal() are successfully generated. However, when generating the script for the checkfile (the check page), these functions are never actually called.
Currently, at the end of the dynamically generated checkfile (around lines 340-347, the code looks like this:

```
if [ "\${et_successful}" -eq 1 ]; then
                exit 0
            else
                echo '<script type="text/javascript">'
                echo -e '\tsetTimeout("redirect()", 3500);'
                echo '</script>'
                exit 1
            fi 
```
Because of this, a wrong password just triggers redirect() (back to index) after 3.5 seconds, and a correct password just exits immediately without showing final.html.
Here is the fixed code:

```
if [ "\${et_successful}" -eq 1 ]; then
                echo '<script type="text/javascript">'
                echo -e '\tsetTimeout("redirectfinal()", 0);'
                echo '</script>'
                exit 0
            else
                echo '<script type="text/javascript">'
                echo -e '\tsetTimeout("redirecterror()", 0);'
                echo '</script>'
                exit 1
            fi
```
Thanks for your work on this plugin!